### PR TITLE
Add double-quoted strings

### DIFF
--- a/syntaxes/clio.tmLanguage.json
+++ b/syntaxes/clio.tmLanguage.json
@@ -107,14 +107,29 @@
 					"begin": "(^|[\\[\\(\\s])(\\')",
 					"beginCaptures": {
 						"2": {
-							"name": "punctuation.clio"
+							"name": "string.single.clio"
 						}
 					},
 					"contentName": "string.single.clio",
 					"end": "(?<!\\\\)(\\')",
 					"endCaptures": {
 						"1": {
-							"name": "punctuation.clio"
+							"name": "string.single.clio"
+						}
+					}
+				},
+				{
+					"begin": "(^|[\\[\\(\\s])(\")",
+					"beginCaptures": {
+						"2": {
+							"name": "string.double.clio"
+						}
+					},
+					"contentName": "string.double.clio",
+					"end": "(?<!\\\\)(\")",
+					"endCaptures": {
+						"1": {
+							"name": "string.double.clio"
 						}
 					}
 				},


### PR DESCRIPTION
I have added syntax highlighting for double-quoted strings. I have also fixed that strings are highlighted without the surrounding quotes.